### PR TITLE
unexpected token on line 35/36 (depending of the file). (fix)

### DIFF
--- a/GameData/NearFutureConstruction/Parts/Adapters/adapter-125/adapter-125-0625-2.cfg
+++ b/GameData/NearFutureConstruction/Parts/Adapters/adapter-125/adapter-125-0625-2.cfg
@@ -32,7 +32,7 @@ PART {
 	manufacturer = #autoLOC_501629 // #autoLOC_501629 = O.M.B. Demolition Enterprises
 	description = #LOC_NFConstruction_adapter-125-0625-2_description
 
-	allowSrfAttach, allowCollision
+	// stack, ¬srfAttach, allowStack, allowSrfAttach, ¬allowCollision
 	attachRules = 1,0,1,1,0
 	stackSymmetry = 1
 

--- a/GameData/NearFutureConstruction/Parts/Adapters/adapter-125/adapter-125-0625-3.cfg
+++ b/GameData/NearFutureConstruction/Parts/Adapters/adapter-125/adapter-125-0625-3.cfg
@@ -32,7 +32,7 @@ PART {
 	manufacturer = #autoLOC_501629 // #autoLOC_501629 = O.M.B. Demolition Enterprises
 	description = #LOC_NFConstruction_adapter-125-0625-3_description
 
-	allowSrfAttach, allowCollision
+	// stack, ¬srfAttach, allowStack, allowSrfAttach, ¬allowCollision
 	attachRules = 1,0,1,1,0
 	stackSymmetry = 2
 

--- a/GameData/NearFutureConstruction/Parts/Adapters/adapter-125/adapter-125-0625-4.cfg
+++ b/GameData/NearFutureConstruction/Parts/Adapters/adapter-125/adapter-125-0625-4.cfg
@@ -33,7 +33,7 @@ PART {
 	manufacturer = #autoLOC_501629 // #autoLOC_501629 = O.M.B. Demolition Enterprises
 	description = #LOC_NFConstruction_adapter-125-0625-4_description
 
-	allowSrfAttach, allowCollision
+	// stack, ¬srfAttach, allowStack, allowSrfAttach, ¬allowCollision
 	attachRules = 1,0,1,1,0
 	stackSymmetry = 3
 


### PR DESCRIPTION
I currently running a lint tool <yada, yada, yada - it's the same history from my pull request on NFA! :) ).

This time is a missing "//" on the config. I added it, and updated the remark.

Added comments based on documentation from https://wiki.kerbalspaceprogram.com/wiki/CFG_File_Documentation