### PR TITLE
Minor patch

### DIFF
--- a/GameData/NearFutureConstruction/Parts/Truss/truss-octo/truss-octo-adapter-crew-01.cfg
+++ b/GameData/NearFutureConstruction/Parts/Truss/truss-octo/truss-octo-adapter-crew-01.cfg
@@ -52,7 +52,6 @@ PART
 	breakingTorque = 200
 	maxTemp = 1000
 	thermalMassModifier = 0.4 // I am hollow
-	tags = #LOC_SSPX_sspx-tube-25-1_tags
 	MODULE
 	{
 		name = ModuleColorChanger


### PR DESCRIPTION
truss-octo-adapter-crew-1 has an extra tag property. the first instance seems correct. sp removed the second one.